### PR TITLE
omit mlockall & add SM direction in slave config

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -26,35 +26,39 @@
 			[
 				"buildtarget!='DEBUG'", {
 					"cflags": [
-						"-fno-exceptions",
+						"-fexceptions",
 						"-lstdc++",
 						"-Iinclude",
 						"-g",
+						"-Og",
 						"-lpthread"
 					],
 					"cflags_cc": [
-						"-fno-exceptions",
+						"-fexceptions",
 						"-lstdc++",
 						"-Iinclude",
 						"-g",
+						"-Og",
 						"-lpthread"
 					]
 				},
 				"buildtarget=='DEBUG'", {
 					"cflags": [
 						"-DDEBUG",
-						"-fno-exceptions",
+						"-fexceptions",
 						"-lstdc++",
 						"-Iinclude",
 						"-g",
+						"-Og",
 						"-lpthread"
 					],
 					"cflags_cc": [
 						"-DDEBUG",
-						"-fno-exceptions",
+						"-fexceptions",
 						"-lstdc++",
 						"-Iinclude",
 						"-g",
+						"-Og",
 						"-lpthread"
 					]
 				}

--- a/lib/ecat.lib.js
+++ b/lib/ecat.lib.js
@@ -249,17 +249,11 @@ class ECAT extends EventEmitter{
 
 		const identifier = `${index}:${subindex}`;
 
-		try{
-			if(self._dmnAddr2Idx && self._dmnAddr2Idx[position] != undefined
-				&& typeof(self._dmnAddr2Idx[position][identifier]) === 'number'
-				&& _config.data[self._dmnAddr2Idx[position][identifier]] != undefined){
-				return _config.data[self._dmnAddr2Idx[position][identifier]].value;
-			}
-		} catch(error) {
-			console.error('read domain error:', error);
+		try {
+			return _config.data[self._dmnAddr2Idx[position][identifier]].value;
+		} catch (error) {
+			return undefined;
 		}
-
-		return undefined;
 	}
 
 	/**

--- a/lib/ecat.lib.js
+++ b/lib/ecat.lib.js
@@ -197,6 +197,8 @@ class ECAT extends EventEmitter{
 					const state = args[1];
 					const isOperational = Boolean(ecat.isOperational());
 
+					_config.data = data;
+
 					if(_config.state != state){
 						self._emit('state', state);
 
@@ -225,8 +227,6 @@ class ECAT extends EventEmitter{
 						self._emit('data', data, _cycle.latency.current);
 						self._timer = hrtime.bigint();
 					}
-
-					_config.data = data;
 				} catch(error) {
 					console.error('start Error', error);
 				}
@@ -249,10 +249,14 @@ class ECAT extends EventEmitter{
 
 		const identifier = `${index}:${subindex}`;
 
-		if(self._dmnAddr2Idx && self._dmnAddr2Idx[position] != undefined
-			&& typeof(self._dmnAddr2Idx[position][identifier]) === 'number'
-			&& _config.data[self._dmnAddr2Idx[position][identifier]] != undefined){
-			return _config.data[self._dmnAddr2Idx[position][identifier]].value;
+		try{
+			if(self._dmnAddr2Idx && self._dmnAddr2Idx[position] != undefined
+				&& typeof(self._dmnAddr2Idx[position][identifier]) === 'number'
+				&& _config.data[self._dmnAddr2Idx[position][identifier]] != undefined){
+				return _config.data[self._dmnAddr2Idx[position][identifier]].value;
+			}
+		} catch(error) {
+			console.error('read domain error:', error);
 		}
 
 		return undefined;

--- a/src/ecat.cc
+++ b/src/ecat.cc
@@ -322,6 +322,7 @@ int8_t domain_startup_config(ec_pdo_entry_reg_t **DomainN_regs, int8_t *DomainN_
 					slave_entries[i].position,
 					slave_entries[i].vendor_id,
 					slave_entries[i].product_code,
+					slave_entries[i].sync_index,
 					slave_entries[i].pdo_index,
 					slave_entries[i].index,
 					slave_entries[i].subindex,
@@ -395,7 +396,7 @@ void syncmanager_startup_config(){
 	// add every valid slave and configure sync manager
 	for(i = 0; i < length; i++){
 		processed_index_sub_size = _convert_index_sub_size(slave_entries[i].index, slave_entries[i].subindex, slave_entries[i].size);
-		syncM_index = slave_entries[i].direction % 2 ? 2 : 3;
+		syncM_index = slave_entries[i].sync_index;
 
 #ifdef DEBUG
 		printf("\nSlave%2d 0x%04x 0x%08x %02d-bits\n", slave_entries[i].position, slave_entries[i].pdo_index, processed_index_sub_size, slave_entries[i].size);

--- a/src/ecat.cc
+++ b/src/ecat.cc
@@ -619,7 +619,7 @@ Napi::Value init_slave(const Napi::CallbackInfo& info) {
 		do_sort_slave = info[1].As<Napi::Boolean>() ? 1 : 0;
 	}
 
-	std::string json_path = info[0].ToString().Utf8Value();
+	std::string json_path = info[0].As<Napi::String>();
 
 	int8_t parsing = parse_json_file(
 			&json_path[0],
@@ -752,11 +752,6 @@ void thread_entry(TsfnContext *context) {
 	fprintf(stdout, "\nUsing priority %i\n", param.sched_priority);
 	if (sched_setscheduler(0, SCHED_FIFO, &param) == -1) {
 		perror("sched_setscheduler failed");
-	}
-
-	/* Lock memory */
-	if (mlockall(MCL_CURRENT | MCL_FUTURE) == -1) {
-		fprintf(stderr, "Warning: Failed to lock memory: %s\n", strerror(errno));
 	}
 
 	stack_prefault();

--- a/src/include/config_parser.cpp
+++ b/src/include/config_parser.cpp
@@ -140,6 +140,24 @@ int8_t parse_json_file(const char *filename, slaveEntry **slave_entries, uint8_t
 				watchdog_enabled = (uint8_t) m_syncs["watchdog_enabled"].GetBool();
 			}
 
+			// override default 'direction' value if it's defined
+			if(m_syncs.HasMember("direction")){
+				assert(m_syncs["direction"].IsString());
+
+				std::string sync_direction = m_syncs["direction"].GetString();
+
+				if(sync_direction == "input"){
+					direction = EC_DIR_INPUT;
+				} else if(sync_direction == "output"){
+					direction = EC_DIR_OUTPUT;
+				} else {
+					throw std::invalid_argument(
+						"\"" + sync_direction + "\" is invalid value. "
+						+ "'direction' value must be \"input\" or \"output\""
+					);
+				}
+			}
+
 			rapidjson::Value arr_pdos = m_syncs["pdos"].GetArray();
 			uint8_t size_arr_pdos = arr_pdos.Size();
 

--- a/src/include/config_parser.cpp
+++ b/src/include/config_parser.cpp
@@ -117,6 +117,7 @@ int8_t parse_json_file(const char *filename, slaveEntry **slave_entries, uint8_t
 					0,
 					0,
 					0,
+					0,
 					0
 				};
 
@@ -178,6 +179,7 @@ int8_t parse_json_file(const char *filename, slaveEntry **slave_entries, uint8_t
 							position,
 							vendor_id,
 							product_code,
+							sync_index,
 							pdo_index,
 							0,
 							0,
@@ -243,6 +245,7 @@ int8_t parse_json_file(const char *filename, slaveEntry **slave_entries, uint8_t
 							position,
 							vendor_id,
 							product_code,
+							sync_index,
 							pdo_index,
 							entry_index,
 							entry_subindex,

--- a/src/include/structs_declaration.h
+++ b/src/include/structs_declaration.h
@@ -22,6 +22,7 @@ typedef struct slaveEntry{
 	uint32_t vendor_id; /**< Slave vendor ID. */
 	uint32_t product_code; /**< Slave product code. */
 
+	uint8_t sync_index; /**< SM index. */
 	uint16_t pdo_index; /**< PDO entry index. */
 
 	uint16_t index; /**< PDO entry index. */


### PR DESCRIPTION
- Omitted mlcokall in ecat.cc. mlcokall  is prone to throw illegal instruction (#2) when garbage collector is active
- Added `direction` to define whether a sync manager is `input` or `output`
- sync manager index is no longer deducted from its `direction`